### PR TITLE
feat: create and drop tables statements

### DIFF
--- a/lib/src/statements/column_definition.dart
+++ b/lib/src/statements/column_definition.dart
@@ -1,0 +1,123 @@
+import 'package:postgres_builder/postgres_builder.dart';
+
+/// {@template column_definition}
+/// A column in a table.
+/// {@endtemplate}
+class ColumnDefinition implements SqlStatement {
+  /// {@macro column_definition}
+  const ColumnDefinition({
+    required this.name,
+    required this.type,
+    this.defaultValue,
+    this.nullable = false,
+    this.primaryKey = false,
+    this.unique = false,
+    this.autoIncrement = false,
+    this.check,
+    this.references,
+    this.collate,
+    this.generated,
+    this.isStored = false,
+  });
+
+  /// The name of the column.
+  final String name;
+
+  /// The type of the column.
+  final String type;
+
+  /// The default value of the column.
+  final String? defaultValue;
+
+  /// Whether the column is nullable.
+  final bool nullable;
+
+  /// Whether the column is a primary key.
+  final bool primaryKey;
+
+  /// Whether the column is a unique key.
+  final bool unique;
+
+  /// Whether the column auto-increments.
+  final bool autoIncrement;
+
+  /// A CHECK constraint expression.
+  final String? check;
+
+  /// A foreign key reference in the format 'table(column)'.
+  final String? references;
+
+  /// The collation to use for the column.
+  final String? collate;
+
+  /// The expression for a generated column.
+  final String? generated;
+
+  /// Whether a generated column is STORED (true) or VIRTUAL (false).
+  final bool isStored;
+
+  @override
+  ProcessedSql toSql() {
+    final query = StringBuffer('$name $type');
+
+    if (generated != null) {
+      query
+        ..write(' GENERATED ALWAYS AS ($generated)')
+        ..write(isStored ? ' STORED' : ' VIRTUAL');
+    } else {
+      if (defaultValue != null) {
+        query.write(' DEFAULT ');
+        // Handle string literals and other types appropriately
+        if (defaultValue!.toLowerCase() == 'null') {
+          query.write('NULL');
+        } else if (defaultValue!.toLowerCase() == 'true' ||
+            defaultValue!.toLowerCase() == 'false') {
+          query.write(defaultValue!.toUpperCase());
+        } else if (defaultValue!.startsWith("'") &&
+            defaultValue!.endsWith("'")) {
+          // Already quoted string
+          query.write(defaultValue);
+        } else if (defaultValue!.contains(RegExp('[^a-zA-Z0-9_]'))) {
+          // Contains special characters, needs quoting
+          query.write("'${defaultValue!.replaceAll("'", "''")}'");
+        } else {
+          // Simple value, no quoting needed
+          query.write(defaultValue);
+        }
+      }
+    }
+
+    if (!nullable) {
+      query.write(' NOT NULL');
+    }
+
+    if (autoIncrement) {
+      query.write(' GENERATED ALWAYS AS IDENTITY');
+    }
+
+    if (primaryKey) {
+      query.write(' PRIMARY KEY');
+    }
+
+    if (unique) {
+      query.write(' UNIQUE');
+    }
+
+    if (check != null) {
+      query.write(' CHECK ($check)');
+    }
+
+    if (references != null) {
+      query.write(' REFERENCES $references');
+    }
+
+    if (collate != null) {
+      query.write(' COLLATE $collate');
+    }
+
+    return ProcessedSql(
+      query: query.toString(),
+      parameters: {},
+    );
+  }
+}

--- a/lib/src/statements/create_table.dart
+++ b/lib/src/statements/create_table.dart
@@ -21,8 +21,8 @@ class CreateTable extends SqlStatement {
     }
     query.write('$name (');
     final mappedQuery = columns.map((e) => e.toSql());
-    for (final column in mappedQuery) {
-      final isLast = column == mappedQuery.last;
+    for (final (index, column) in mappedQuery.indexed) {
+      final isLast = index == mappedQuery.length - 1;
       query.write(column.query);
       if (!isLast) {
         query.write(', ');

--- a/lib/src/statements/create_table.dart
+++ b/lib/src/statements/create_table.dart
@@ -1,0 +1,39 @@
+import 'package:postgres_builder/postgres_builder.dart';
+
+class CreateTable extends SqlStatement {
+  const CreateTable({
+    required this.name,
+    required this.columns,
+    this.ifNotExists = false,
+  });
+
+  final String name;
+  final bool ifNotExists;
+  final List<ColumnDefinition> columns;
+
+  @override
+  ProcessedSql toSql() {
+    final query = StringBuffer(
+      'CREATE TABLE ',
+    );
+    if (ifNotExists) {
+      query.write('IF NOT EXISTS ');
+    }
+    query.write('$name (');
+    final mappedQuery = columns.map((e) => e.toSql());
+    for (final column in mappedQuery) {
+      final isLast = column == mappedQuery.last;
+      query.write(column.query);
+      if (!isLast) {
+        query.write(', ');
+      }
+    }
+    query.write(');');
+    return ProcessedSql(
+      query: query.toString(),
+      parameters: {
+        for (final current in mappedQuery) ...current.parameters,
+      },
+    );
+  }
+}

--- a/lib/src/statements/drop_table.dart
+++ b/lib/src/statements/drop_table.dart
@@ -1,0 +1,24 @@
+import 'package:postgres_builder/postgres_builder.dart';
+
+class DropTable extends SqlStatement {
+  const DropTable({
+    required this.name,
+    this.ifExists = false,
+  });
+
+  final String name;
+  final bool ifExists;
+
+  @override
+  ProcessedSql toSql() {
+    final query = StringBuffer('DROP TABLE ');
+    if (ifExists) {
+      query.write('IF EXISTS ');
+    }
+    query.write('$name;');
+    return ProcessedSql(
+      query: query.toString(),
+      parameters: {},
+    );
+  }
+}

--- a/lib/src/statements/statements.dart
+++ b/lib/src/statements/statements.dart
@@ -1,7 +1,10 @@
 export 'and.dart';
 export 'column.dart';
+export 'column_definition.dart';
 export 'comparisons.dart';
+export 'create_table.dart';
 export 'delete.dart';
+export 'drop_table.dart';
 export 'equals.dart';
 export 'group.dart';
 export 'in.dart';

--- a/test/src/statements/column_definition_test.dart
+++ b/test/src/statements/column_definition_test.dart
@@ -153,7 +153,8 @@ void main() {
             generated: 'price * qty',
           ).toSql(),
           equalsSql(
-            query: 'total INTEGER GENERATED ALWAYS AS (price * qty) VIRTUAL',
+            query:
+                '''total INTEGER GENERATED ALWAYS AS (price * qty) VIRTUAL NOT NULL''',
           ),
         );
       });
@@ -166,7 +167,8 @@ void main() {
             isStored: true,
           ).toSql(),
           equalsSql(
-            query: 'total INTEGER GENERATED ALWAYS AS (price * qty) STORED',
+            query:
+                '''total INTEGER GENERATED ALWAYS AS (price * qty) STORED NOT NULL''',
           ),
         );
       });

--- a/test/src/statements/column_definition_test.dart
+++ b/test/src/statements/column_definition_test.dart
@@ -1,0 +1,196 @@
+import 'package:postgres_builder/postgres_builder.dart';
+import 'package:test/test.dart';
+
+import '../../_helpers.dart';
+
+void main() {
+  group('ColumnDefinition', () {
+    test('toSql returns basic column', () {
+      expect(
+        const ColumnDefinition(name: 'id', type: 'INTEGER').toSql(),
+        equalsSql(query: 'id INTEGER NOT NULL'),
+      );
+    });
+
+    test('toSql with nullable', () {
+      expect(
+        const ColumnDefinition(name: 'id', type: 'INTEGER', nullable: true)
+            .toSql(),
+        equalsSql(query: 'id INTEGER'),
+      );
+    });
+
+    test('toSql with primaryKey', () {
+      expect(
+        const ColumnDefinition(name: 'id', type: 'INTEGER', primaryKey: true)
+            .toSql(),
+        equalsSql(query: 'id INTEGER NOT NULL PRIMARY KEY'),
+      );
+    });
+
+    test('toSql with unique', () {
+      expect(
+        const ColumnDefinition(name: 'email', type: 'TEXT', unique: true)
+            .toSql(),
+        equalsSql(query: 'email TEXT NOT NULL UNIQUE'),
+      );
+    });
+
+    test('toSql with autoIncrement', () {
+      expect(
+        const ColumnDefinition(name: 'id', type: 'INTEGER', autoIncrement: true)
+            .toSql(),
+        equalsSql(query: 'id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY'),
+      );
+    });
+
+    test('toSql with check', () {
+      expect(
+        const ColumnDefinition(name: 'age', type: 'INTEGER', check: 'age > 0')
+            .toSql(),
+        equalsSql(query: 'age INTEGER NOT NULL CHECK (age > 0)'),
+      );
+    });
+
+    test('toSql with references', () {
+      expect(
+        const ColumnDefinition(
+          name: 'user_id',
+          type: 'INTEGER',
+          references: 'users(id)',
+        ).toSql(),
+        equalsSql(query: 'user_id INTEGER NOT NULL REFERENCES users(id)'),
+      );
+    });
+
+    test('toSql with collate', () {
+      expect(
+        const ColumnDefinition(name: 'name', type: 'TEXT', collate: 'en_US')
+            .toSql(),
+        equalsSql(query: 'name TEXT NOT NULL COLLATE en_US'),
+      );
+    });
+
+    group('defaultValue', () {
+      test('simple value', () {
+        expect(
+          const ColumnDefinition(
+            name: 'age',
+            type: 'INTEGER',
+            defaultValue: '18',
+          ).toSql(),
+          equalsSql(query: 'age INTEGER DEFAULT 18 NOT NULL'),
+        );
+      });
+      test('null', () {
+        expect(
+          const ColumnDefinition(
+            name: 'foo',
+            type: 'TEXT',
+            defaultValue: 'null',
+          ).toSql(),
+          equalsSql(query: 'foo TEXT DEFAULT NULL NOT NULL'),
+        );
+      });
+      test('boolean true', () {
+        expect(
+          const ColumnDefinition(
+            name: 'flag',
+            type: 'BOOLEAN',
+            defaultValue: 'true',
+          ).toSql(),
+          equalsSql(query: 'flag BOOLEAN DEFAULT TRUE NOT NULL'),
+        );
+      });
+      test('boolean false', () {
+        expect(
+          const ColumnDefinition(
+            name: 'flag',
+            type: 'BOOLEAN',
+            defaultValue: 'false',
+          ).toSql(),
+          equalsSql(query: 'flag BOOLEAN DEFAULT FALSE NOT NULL'),
+        );
+      });
+      test('already quoted string', () {
+        expect(
+          const ColumnDefinition(
+            name: 'foo',
+            type: 'TEXT',
+            defaultValue: "'bar'",
+          ).toSql(),
+          equalsSql(query: "foo TEXT DEFAULT 'bar' NOT NULL"),
+        );
+      });
+      test('string with special chars', () {
+        expect(
+          const ColumnDefinition(
+            name: 'foo',
+            type: 'TEXT',
+            defaultValue: "bar's baz",
+          ).toSql(),
+          equalsSql(query: "foo TEXT DEFAULT 'bar''s baz' NOT NULL"),
+        );
+      });
+      test('string with only safe chars', () {
+        expect(
+          const ColumnDefinition(
+            name: 'foo',
+            type: 'TEXT',
+            defaultValue: 'bar_baz',
+          ).toSql(),
+          equalsSql(query: 'foo TEXT DEFAULT bar_baz NOT NULL'),
+        );
+      });
+    });
+
+    group('generated columns', () {
+      test('virtual', () {
+        expect(
+          const ColumnDefinition(
+            name: 'total',
+            type: 'INTEGER',
+            generated: 'price * qty',
+          ).toSql(),
+          equalsSql(
+            query: 'total INTEGER GENERATED ALWAYS AS (price * qty) VIRTUAL',
+          ),
+        );
+      });
+      test('stored', () {
+        expect(
+          const ColumnDefinition(
+            name: 'total',
+            type: 'INTEGER',
+            generated: 'price * qty',
+            isStored: true,
+          ).toSql(),
+          equalsSql(
+            query: 'total INTEGER GENERATED ALWAYS AS (price * qty) STORED',
+          ),
+        );
+      });
+    });
+
+    test('toSql with all modifiers', () {
+      expect(
+        const ColumnDefinition(
+          name: 'id',
+          type: 'INTEGER',
+          defaultValue: '42',
+          nullable: true,
+          primaryKey: true,
+          unique: true,
+          autoIncrement: true,
+          check: 'id > 0',
+          references: 'other(id)',
+          collate: 'en_US',
+        ).toSql(),
+        equalsSql(
+          query:
+              '''id INTEGER DEFAULT 42 GENERATED ALWAYS AS IDENTITY PRIMARY KEY UNIQUE CHECK (id > 0) REFERENCES other(id) COLLATE en_US''',
+        ),
+      );
+    });
+  });
+}

--- a/test/src/statements/create_table_test.dart
+++ b/test/src/statements/create_table_test.dart
@@ -1,0 +1,28 @@
+import 'package:postgres_builder/postgres_builder.dart';
+import 'package:test/test.dart';
+
+import '../../_helpers.dart';
+
+void main() {
+  group('CreateTable', () {
+    test('toSql returns correctly', () {
+      final columns = [
+        const ColumnDefinition(name: 'id', type: 'SERIAL', primaryKey: true),
+        const ColumnDefinition(name: 'name', type: 'TEXT'),
+      ];
+      final statement = CreateTable(
+        name: 'users',
+        columns: columns,
+        ifNotExists: true,
+      );
+      expect(
+        statement.toSql(),
+        equalsSql(
+          query:
+              '''CREATE TABLE IF NOT EXISTS users (id SERIAL NOT NULL PRIMARY KEY, name TEXT NOT NULL);''',
+          parameters: {},
+        ),
+      );
+    });
+  });
+}

--- a/test/src/statements/drop_table_test.dart
+++ b/test/src/statements/drop_table_test.dart
@@ -1,0 +1,28 @@
+import 'package:postgres_builder/postgres_builder.dart';
+import 'package:test/test.dart';
+
+import '../../_helpers.dart';
+
+void main() {
+  group('DropTable', () {
+    test('toSql returns correctly without ifExists', () {
+      expect(
+        const DropTable(name: '__table__').toSql(),
+        equalsSql(
+          query: 'DROP TABLE __table__;',
+          parameters: {},
+        ),
+      );
+    });
+
+    test('toSql returns correctly with ifExists', () {
+      expect(
+        const DropTable(name: '__table__', ifExists: true).toSql(),
+        equalsSql(
+          query: 'DROP TABLE IF EXISTS __table__;',
+          parameters: {},
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces new classes and tests to support SQL statement generation for PostgreSQL, including column definitions and table creation/drop operations. The changes focus on enhancing the library's functionality for building SQL queries programmatically.

### New SQL Statement Classes:

* [`lib/src/statements/column_definition.dart`](diffhunk://#diff-887068722e914c8c61cf6d40c6cc5a81592e13d06ca3cf1ea009421c95bdc3c0R1-R123): Added the `ColumnDefinition` class to define table columns with attributes like `type`, `nullable`, `primaryKey`, `unique`, and more. Includes logic to generate SQL strings for column definitions.
* [`lib/src/statements/create_table.dart`](diffhunk://#diff-18fa55d878e2869fddb0cd23cb7d2f226826d7f30b35133dc837da9871c07dd3R1-R39): Added the `CreateTable` class to generate SQL for creating tables, supporting options like `ifNotExists` and a list of `ColumnDefinition` objects.
* [`lib/src/statements/drop_table.dart`](diffhunk://#diff-8d1d6974e92e83888fedf066805511dbd537c3fd5f80ee5191b7b2d8965a8389R1-R24): Added the `DropTable` class to generate SQL for dropping tables, with support for the `ifExists` option.

### Updates to Exports:

* [`lib/src/statements/statements.dart`](diffhunk://#diff-53d41d756e04864439afabce9a9aa130014411e66a7d636b6bc521c45f026b52R3-R7): Updated exports to include the newly added `column_definition.dart`, `create_table.dart`, and `drop_table.dart` files.

### Unit Tests:

* [`test/src/statements/column_definition_test.dart`](diffhunk://#diff-772e5f2ce611c43324f8ba7daf370d3753ef8639a2f53404a0ab2f47705bfad2R1-R196): Added comprehensive tests for `ColumnDefinition` to validate SQL generation with various modifiers like `nullable`, `primaryKey`, `unique`, `defaultValue`, `check`, and `references`.
* [`test/src/statements/create_table_test.dart`](diffhunk://#diff-5c76c383f1304221b922cf0b17dc8fa14313a715caa94e5ce68d697c7ba08e6dR1-R28): Added tests for `CreateTable` to ensure correct SQL generation for table creation with multiple columns and the `ifNotExists` option.
* [`test/src/statements/drop_table_test.dart`](diffhunk://#diff-a4783e6fac2a5aa8418976108e6a6c067e141884cdc806535c633d741a49ce32R1-R28): Added tests for `DropTable` to verify SQL generation for dropping tables with and without the `ifExists` option.