### PR TITLE
chore: 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+- Added `CreateTable` to support `CREATE TABLE` statements
+- Added `DropTable` to support `DROP TABLE` statements
+
 ## 2.1.0
 
 - Added `Between` to support `BETWEEN` clauses

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres_builder
 description: A tool designed to make writing PostgreSQL statements easier without writing them by hand.
-version: 2.1.0
+version: 2.2.0
 repository: https://github.com/Morel-Tech/dart_postgres_builder
 issue_tracker: https://github.com/Morel-Tech/dart_postgres_builder/issues
 


### PR DESCRIPTION
This pull request introduces version 2.2.0 of the `postgres_builder` package, adding support for `CREATE TABLE` and `DROP TABLE` statements. The version number has been updated accordingly.

### Key Changes:

#### New Features:
* Added `CreateTable` to support `CREATE TABLE` statements. (`CHANGELOG.md`, [CHANGELOG.mdR1-R5](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5))
* Added `DropTable` to support `DROP TABLE` statements. (`CHANGELOG.md`, [CHANGELOG.mdR1-R5](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R5))

#### Version Update:
* Updated the version in `pubspec.yaml` from 2.1.0 to 2.2.0. (`pubspec.yaml`, [pubspec.yamlL3-R3](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3))