### PR TITLE
chore: release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+- Exported `ConnectionSettings`
+- Fixed `ColumnDefinition` to not automatically quote default values
+
 ## 2.2.0
 
 - Added `CreateTable` to support `CREATE TABLE` statements

--- a/lib/postgres_builder.dart
+++ b/lib/postgres_builder.dart
@@ -2,7 +2,7 @@
 library postgres_builder;
 
 export 'package:postgres/postgres.dart'
-    show Endpoint, Pool, PoolSettings, SslMode;
+    show ConnectionSettings, Endpoint, Pool, PoolSettings, SslMode;
 
 export 'src/direct_postgres_builder.dart';
 export 'src/pg_pool_postgres_builder.dart';

--- a/lib/src/statements/column_definition.dart
+++ b/lib/src/statements/column_definition.dart
@@ -73,13 +73,6 @@ class ColumnDefinition implements SqlStatement {
         } else if (defaultValue!.toLowerCase() == 'true' ||
             defaultValue!.toLowerCase() == 'false') {
           query.write(defaultValue!.toUpperCase());
-        } else if (defaultValue!.startsWith("'") &&
-            defaultValue!.endsWith("'")) {
-          // Already quoted string
-          query.write(defaultValue);
-        } else if (defaultValue!.contains(RegExp('[^a-zA-Z0-9_]'))) {
-          // Contains special characters, needs quoting
-          query.write("'${defaultValue!.replaceAll("'", "''")}'");
         } else {
           // Simple value, no quoting needed
           query.write(defaultValue);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres_builder
 description: A tool designed to make writing PostgreSQL statements easier without writing them by hand.
-version: 2.2.0
+version: 2.2.1
 repository: https://github.com/Morel-Tech/dart_postgres_builder
 issue_tracker: https://github.com/Morel-Tech/dart_postgres_builder/issues
 

--- a/test/src/statements/column_definition_test.dart
+++ b/test/src/statements/column_definition_test.dart
@@ -129,7 +129,7 @@ void main() {
             type: 'TEXT',
             defaultValue: "bar's baz",
           ).toSql(),
-          equalsSql(query: "foo TEXT DEFAULT 'bar''s baz' NOT NULL"),
+          equalsSql(query: "foo TEXT DEFAULT bar's baz NOT NULL"),
         );
       });
       test('string with only safe chars', () {


### PR DESCRIPTION
This pull request introduces version `2.2.1` of the `postgres_builder` package, with key changes including the export of `ConnectionSettings`, a fix to the `ColumnDefinition` class to prevent automatic quoting of default values, and updates to the versioning and documentation.

### New Features and Exports:
* Added `ConnectionSettings` to the exports in `lib/postgres_builder.dart`. This makes the `ConnectionSettings` class available for external use.

### Bug Fixes:
* Fixed `ColumnDefinition` to no longer automatically quote default values. This change ensures that values are treated as-is unless explicitly specified. [[1]](diffhunk://#diff-887068722e914c8c61cf6d40c6cc5a81592e13d06ca3cf1ea009421c95bdc3c0L76-L82) [[2]](diffhunk://#diff-772e5f2ce611c43324f8ba7daf370d3753ef8639a2f53404a0ab2f47705bfad2L132-R132)

### Versioning and Documentation:
* Updated the package version to `2.2.1` in `pubspec.yaml`.
* Added a new section for version `2.2.1` in the `CHANGELOG.md` to document the changes, including the export of `ConnectionSettings` and the fix to `ColumnDefinition`.