### PR TITLE
fix: Not to accept any SqlStatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+- Fixed `Not` to accept any `SqlStatement`
+
 ## 2.6.0
 
 - Added `Exists` to support `EXISTS` clauses

--- a/lib/src/statements/not.dart
+++ b/lib/src/statements/not.dart
@@ -3,7 +3,7 @@ import 'package:postgres_builder/postgres_builder.dart';
 class Not extends FilterStatement {
   const Not(this.column);
 
-  final Column column;
+  final SqlStatement column;
 
   @override
   ProcessedSql toSql() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres_builder
 description: A tool designed to make writing PostgreSQL statements easier without writing them by hand.
-version: 2.6.0
+version: 2.6.1
 repository: https://github.com/mtwichel/dart_postgres_builder
 issue_tracker: https://github.com/mtwichel/dart_postgres_builder/issues
 


### PR DESCRIPTION
This PR fixes the `Not` statement to accept any `SqlStatement` instead of just `Column`, making it more flexible and consistent with other statements.

Changes:
- Changed `Not.column` from `Column` to `SqlStatement` type
- Updated version to 2.6.1
- Added changelog entry