### PR TITLE
feat: add HAVING clause support to Select statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed `Not` to accept any `SqlStatement`
 - Added `equalsOtherColumn` to `Column` to support comparing two columns
 - Added aggregate functions: `Count`, `Sum`, `Avg`, `Max`, `Min`, `StringAgg`, `ArrayAgg`
+- Added having support to aggregate functions
 
 ## 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Select(
   int? limit,
   List<Join>? join,
   Group? group,
+  FilterStatement? having,
 })
 ```
 
@@ -87,11 +88,12 @@ Select(
 
 - `columns`: List of columns or expressions to select
 - `from`: Table name (required)
-- `where`: Optional WHERE clause filter
+- `where`: Optional WHERE clause filter (filters rows before grouping)
 - `order`: Optional list of Sort objects for ORDER BY
 - `limit`: Optional limit for number of rows
 - `join`: Optional list of Join objects
 - `group`: Optional Group object for GROUP BY
+- `having`: Optional HAVING clause filter (filters grouped results after GROUP BY)
 
 #### Insert
 
@@ -423,6 +425,81 @@ Select(
 ```
 
 This generates: `SELECT department, COUNT(*) AS "count", AVG(age) AS "avg_age", SUM(salary) AS "total_salary" FROM users GROUP BY department`
+
+#### Aggregate Functions with HAVING Clause
+
+The HAVING clause allows you to filter grouped results based on aggregate function values. This is different from WHERE, which filters rows before grouping.
+
+**Example:**
+
+```dart
+Select(
+  [
+    Column('age'),
+    Count.star(as: 'count'),
+  ],
+  from: 'users',
+  group: Group([Column('age')]),
+  having: Count.star().greaterThan(5),
+)
+```
+
+This generates: `SELECT age, COUNT(*) AS "count" FROM users GROUP BY age HAVING COUNT(*) > @param_...`
+
+**Using HAVING with multiple conditions:**
+
+```dart
+Select(
+  [
+    Column('department'),
+    Count.star(as: 'count'),
+    Avg(Column('age'), as: 'avg_age'),
+  ],
+  from: 'users',
+  group: Group([Column('department')]),
+  having: Count.star().greaterThan(5) & Avg(Column('age')).greaterThan(30),
+)
+```
+
+**Using both WHERE and HAVING:**
+
+```dart
+Select(
+  [
+    Column('department'),
+    Count.star(as: 'count'),
+  ],
+  from: 'users',
+  where: Column('active').equals(true),  // Filters rows before grouping
+  group: Group([Column('department')]),
+  having: Count.star().greaterThan(10),  // Filters groups after grouping
+)
+```
+
+#### Aggregate Function Comparison Methods
+
+All aggregate functions support comparison methods for use in HAVING clauses:
+
+- `equals(dynamic other)`: Creates an Equals filter (aggregate = value)
+- `notEquals(dynamic other)`: Creates a NotEquals filter (aggregate != value)
+- `greaterThan(dynamic other)`: Creates a GreaterThan filter (aggregate > value)
+- `greaterThanOrEqual(dynamic other)`: Creates a GreaterThanOrEqual filter (aggregate >= value)
+- `lessThan(dynamic other)`: Creates a LessThan filter (aggregate < value)
+- `lessThanOrEqual(dynamic other)`: Creates a LessThanOrEqual filter (aggregate <= value)
+- `between(dynamic lowerValue, dynamic upperValue)`: Creates a Between filter
+
+**Example:**
+
+```dart
+// Filter groups where count is greater than 5
+having: Count.star().greaterThan(5)
+
+// Filter groups where average age is between 25 and 65
+having: Avg(Column('age')).between(25, 65)
+
+// Combine multiple conditions
+having: Count.star().greaterThan(10) & Avg(Column('salary')).lessThan(50000)
+```
 
 ### Filter and Comparison Operations
 

--- a/lib/src/statements/aggregate_function.dart
+++ b/lib/src/statements/aggregate_function.dart
@@ -31,4 +31,28 @@ abstract class AggregateFunction implements SqlStatement {
       parameters: expressionSql.parameters,
     );
   }
+
+  /// Creates an Equals filter (aggregate = value)
+  Equals equals(dynamic other) => Equals(this, other);
+
+  /// Creates a NotEquals filter (aggregate != value)
+  NotEquals notEquals(dynamic other) => NotEquals(this, other);
+
+  /// Creates a GreaterThan filter (aggregate > value)
+  GreaterThan greaterThan(dynamic other) => GreaterThan(this, other);
+
+  /// Creates a GreaterThanOrEqual filter (aggregate >= value)
+  GreaterThanOrEqual greaterThanOrEqual(dynamic other) =>
+      GreaterThanOrEqual(this, other);
+
+  /// Creates a LessThan filter (aggregate < value)
+  LessThan lessThan(dynamic other) => LessThan(this, other);
+
+  /// Creates a LessThanOrEqual filter (aggregate <= value)
+  LessThanOrEqual lessThanOrEqual(dynamic other) =>
+      LessThanOrEqual(this, other);
+
+  /// Creates a Between filter
+  Between between(dynamic lowerValue, dynamic upperValue) =>
+      Between(this, lowerValue, upperValue);
 }

--- a/lib/src/statements/comparisons.dart
+++ b/lib/src/statements/comparisons.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:postgres_builder/postgres_builder.dart';
 
 class GreaterThan extends OperatorComparison {
@@ -23,20 +25,43 @@ class LessThanOrEqual extends OperatorComparison {
 class Between extends FilterStatement {
   const Between(this.column, this.lowerValue, this.upperValue);
 
-  final Column column;
+  final SqlStatement column;
   final dynamic lowerValue;
   final dynamic upperValue;
 
+  String _getParameterName() {
+    if (column is Column) {
+      return (column as Column).parameterName;
+    }
+    // Generate a unique parameter name for non-Column SqlStatements
+    return 'param_${_generateRandomString()}';
+  }
+
+  String _generateRandomString({int length = 16}) {
+    final random = Random();
+    const letters = 'abcdefghijklmnopqrstuvwxyz';
+
+    return String.fromCharCodes(
+      Iterable.generate(
+        length,
+        (_) => letters.codeUnitAt(random.nextInt(letters.length)),
+      ),
+    );
+  }
+
   @override
   ProcessedSql toSql() {
-    final columnSql = column.toSql().query;
+    final columnSqlResult = column.toSql();
+    final columnSql = columnSqlResult.query;
+    final parameterName = _getParameterName();
 
     return ProcessedSql(
-      query: '$columnSql BETWEEN @${column.parameterName}_lower '
-          'AND @${column.parameterName}_upper',
+      query: '$columnSql BETWEEN @${parameterName}_lower '
+          'AND @${parameterName}_upper',
       parameters: {
-        '${column.parameterName}_lower': lowerValue,
-        '${column.parameterName}_upper': upperValue,
+        ...columnSqlResult.parameters,
+        '${parameterName}_lower': lowerValue,
+        '${parameterName}_upper': upperValue,
       },
     );
   }

--- a/lib/src/statements/operator_comparison.dart
+++ b/lib/src/statements/operator_comparison.dart
@@ -20,28 +20,40 @@ class OperatorComparison extends FilterStatement {
         useParameter = false,
         columnFirst = false;
 
-  final Column column;
+  final SqlStatement column;
   final dynamic value;
   final bool useParameter;
   final String operator;
   final bool columnFirst;
 
+  String _getParameterName() {
+    if (column is Column) {
+      return (column as Column).parameterName;
+    }
+    // Generate a unique parameter name for non-Column SqlStatements
+    return 'param_${generateRandomString()}';
+  }
+
   @override
   ProcessedSql toSql() {
-    final columnSql = column.toSql().query;
+    final columnSqlResult = column.toSql();
+    final columnSql = columnSqlResult.query;
     if (useParameter) {
-      final parameterName = column.parameterName;
+      final parameterName = _getParameterName();
       return ProcessedSql(
         query: columnFirst
             ? '$columnSql $operator @$parameterName'
             : '@$parameterName $operator $columnSql',
-        parameters: {parameterName: value},
+        parameters: {
+          ...columnSqlResult.parameters,
+          parameterName: value,
+        },
       );
     }
 
     return ProcessedSql(
       query: '$columnSql $operator $value',
-      parameters: {},
+      parameters: columnSqlResult.parameters,
     );
   }
 }

--- a/lib/src/statements/select.dart
+++ b/lib/src/statements/select.dart
@@ -9,6 +9,7 @@ class Select implements SqlStatement {
     this.limit,
     this.join,
     this.group,
+    this.having,
   }) : table = from;
 
   final List<SqlStatement> columns;
@@ -18,12 +19,17 @@ class Select implements SqlStatement {
   final int? limit;
   final Group? group;
   final List<Join>? join;
+  final FilterStatement? having;
 
   @override
   ProcessedSql toSql() {
     ProcessedSql? processedWhere;
     if (where != null) {
       processedWhere = where!.toSql();
+    }
+    ProcessedSql? processedHaving;
+    if (having != null) {
+      processedHaving = having!.toSql();
     }
     final query = [
       'SELECT',
@@ -36,6 +42,10 @@ class Select implements SqlStatement {
         processedWhere.query,
       ],
       if (group != null) group!.toSql().query,
+      if (processedHaving != null) ...[
+        'HAVING',
+        processedHaving.query,
+      ],
       if (order != null)
         'ORDER BY ${order!.map((e) => e.toSql().query).join(', ')}',
       if (limit != null) 'LIMIT $limit',
@@ -45,6 +55,7 @@ class Select implements SqlStatement {
       query: query,
       parameters: {
         ...?processedWhere?.parameters,
+        ...?processedHaving?.parameters,
         for (final column in columns) ...column.toSql().parameters,
         if (join != null)
           for (final currentJoin in join!) ...currentJoin.toSql().parameters,

--- a/test/src/statements/aggregate_function_integration_test.dart
+++ b/test/src/statements/aggregate_function_integration_test.dart
@@ -87,5 +87,107 @@ void main() {
         ),
       );
     });
+
+    test('Aggregates with HAVING clause', () {
+      final result = Select(
+        [
+          const Column('age'),
+          const Count.star(as: 'count'),
+        ],
+        from: 'users',
+        group: Group([const Column('age')]),
+        having: const Count.star().greaterThan(5),
+      ).toSql();
+
+      expect(
+        result.query,
+        equals(
+          'SELECT age, COUNT(*) AS "count" FROM users '
+          'GROUP BY age HAVING COUNT(*) > @${result.parameters.keys.first}',
+        ),
+      );
+      expect(result.parameters.values.first, equals(5));
+      expect(result.parameters.length, equals(1));
+    });
+
+    test('Aggregates with HAVING clause using multiple conditions', () {
+      final result = Select(
+        [
+          const Column('department'),
+          const Count.star(as: 'count'),
+          const Avg(Column('age'), as: 'avg_age'),
+        ],
+        from: 'users',
+        group: Group([const Column('department')]),
+        having: const Count.star().greaterThan(5) &
+            const Avg(Column('age')).greaterThan(30),
+      ).toSql();
+
+      expect(
+        result.query,
+        contains('SELECT department, COUNT(*) AS "count", '
+            'AVG(age) AS "avg_age" FROM users GROUP BY department '
+            'HAVING (COUNT(*) > @'),
+      );
+      expect(result.query, contains(' AND AVG(age) > @'));
+      expect(result.parameters.length, equals(2));
+      expect(result.parameters.values, containsAll([5, 30]));
+    });
+
+    test('Aggregates with WHERE and HAVING clauses', () {
+      final result = Select(
+        [
+          const Column('department'),
+          const Count.star(as: 'count'),
+        ],
+        from: 'users',
+        where: const Column('active').equals(true),
+        group: Group([const Column('department')]),
+        having: const Count.star().greaterThan(10),
+      ).toSql();
+
+      expect(
+        result.query,
+        contains('SELECT department, COUNT(*) AS "count" FROM users '
+            'WHERE active = @active GROUP BY department '
+            'HAVING COUNT(*) > @'),
+      );
+      expect(result.parameters['active'], equals(true));
+      expect(result.parameters.length, equals(2));
+      expect(result.parameters.values, contains(10));
+    });
+
+    test('Aggregates with parameters preserved in HAVING clause', () {
+      // Test that parameters from aggregate functions
+      // (like StringAgg with orderBy) are preserved when used in HAVING clauses
+      final result = Select(
+        [
+          const Column('department'),
+          const StringAgg(
+            Column('name'),
+            ', ',
+            orderBy: [Sort(Column('id'))],
+            as: 'names',
+          ),
+        ],
+        from: 'users',
+        group: Group([const Column('department')]),
+        having: const StringAgg(
+          Column('name'),
+          ', ',
+          orderBy: [Sort(Column('id'))],
+        ).greaterThan('test'),
+      ).toSql();
+
+      // Verify the query contains the HAVING clause
+      expect(
+        result.query,
+        contains("HAVING STRING_AGG(name, ', ' ORDER BY id ASC) > @"),
+      );
+      // Verify parameters are present (the comparison value and any from
+      // the aggregate)
+      expect(result.parameters.length, greaterThanOrEqualTo(1));
+      expect(result.parameters.values, contains('test'));
+    });
   });
 }

--- a/test/src/statements/select_test.dart
+++ b/test/src/statements/select_test.dart
@@ -121,6 +121,106 @@ void main() {
           ),
         );
       });
+
+      test('with having is provided', () {
+        final column = _MockColumn();
+        final having = _MockFilterStatement();
+        when(column.toSql).thenReturn(
+          const ProcessedSql(query: '__column__', parameters: {}),
+        );
+        when(having.toSql).thenReturn(
+          const ProcessedSql(
+            query: '__having__',
+            parameters: {'__key__': '__value__'},
+          ),
+        );
+
+        final select = Select([column], having: having, from: '__table__');
+        expect(
+          select.toSql(),
+          equalsSql(
+            query: '''SELECT __column__ FROM __table__ HAVING __having__''',
+            parameters: {'__key__': '__value__'},
+          ),
+        );
+      });
+
+      test('with group and having is provided', () {
+        final column = _MockColumn();
+        final group = _MockGroup();
+        final having = _MockFilterStatement();
+        when(column.toSql).thenReturn(
+          const ProcessedSql(query: '__column__', parameters: {}),
+        );
+        when(group.toSql).thenReturn(
+          const ProcessedSql(query: '__group__', parameters: {}),
+        );
+        when(having.toSql).thenReturn(
+          const ProcessedSql(
+            query: '__having__',
+            parameters: {'__key__': '__value__'},
+          ),
+        );
+
+        final select = Select(
+          [column],
+          group: group,
+          having: having,
+          from: '__table__',
+        );
+        expect(
+          select.toSql(),
+          equalsSql(
+            query:
+                '''SELECT __column__ FROM __table__ __group__ HAVING __having__''',
+            parameters: {'__key__': '__value__'},
+          ),
+        );
+      });
+
+      test('with where, group, and having is provided', () {
+        final column = _MockColumn();
+        final where = _MockFilterStatement();
+        final group = _MockGroup();
+        final having = _MockFilterStatement();
+        when(column.toSql).thenReturn(
+          const ProcessedSql(query: '__column__', parameters: {}),
+        );
+        when(where.toSql).thenReturn(
+          const ProcessedSql(
+            query: '__where__',
+            parameters: {'__where_key__': '__where_value__'},
+          ),
+        );
+        when(group.toSql).thenReturn(
+          const ProcessedSql(query: '__group__', parameters: {}),
+        );
+        when(having.toSql).thenReturn(
+          const ProcessedSql(
+            query: '__having__',
+            parameters: {'__having_key__': '__having_value__'},
+          ),
+        );
+
+        final select = Select(
+          [column],
+          where: where,
+          group: group,
+          having: having,
+          from: '__table__',
+        );
+        expect(
+          select.toSql(),
+          equalsSql(
+            query:
+                '''SELECT __column__ FROM __table__ WHERE __where__ __group__ HAVING __having__''',
+            parameters: {
+              '__where_key__': '__where_value__',
+              '__having_key__': '__having_value__',
+            },
+          ),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

This PR adds HAVING clause support to Select statements, allowing filtering of grouped results based on aggregate function values.

## Changes

- Added `having` parameter to `Select` constructor
- Enabled aggregate functions to be used in comparisons via comparison methods (`greaterThan`, `lessThan`, `equals`, etc.)
- Extended `OperatorComparison` and `Between` to accept `SqlStatement` instead of just `Column`
- Fixed parameter preservation: parameters from aggregate functions are now properly merged in comparison operations
- Added comprehensive tests for HAVING clause functionality
- Updated README with HAVING clause documentation and examples

## Usage Example

```dart
Select(
  [Column('age'), Count.star(as: 'count')],
  from: 'users',
  group: Group([Column('age')]),
  having: Count.star().greaterThan(5),
)
```

This generates: `SELECT age, COUNT(*) AS "count" FROM users GROUP BY age HAVING COUNT(*) > @param_...`

## Testing

- All existing tests pass
- Added unit tests for HAVING clause in `select_test.dart`
- Added integration tests for aggregate functions with HAVING clause
- Fixed linter warnings

Fixes #43